### PR TITLE
docs: change README example bullet links to download zip files

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -68,21 +68,21 @@ are publicly available 3d scans of the Hamby-Brundage bullet set #44 provided by
 
 Download: 
 
-  - [Known Bullets 1 and 2 from Barrel 1](examples/Hamby-44/barrel 1.zip)
-  - Questioned bullets:  [E](examples/Hamby-44/Questioned//Bullet E.zip), 
-  [F](examples/Hamby-44/Questioned//Bullet F.zip), 
-[G](examples/Hamby-44/Questioned//Bullet G.zip), 
-[H](examples/Hamby-44/Questioned//Bullet H.zip), 
-[I](examples/Hamby-44/Questioned//Bullet I.zip), 
-[J](examples/Hamby-44/Questioned//Bullet J.zip), 
-[K](examples/Hamby-44/Questioned//Bullet K.zip), 
-[L](examples/Hamby-44/Questioned//Bullet L.zip), 
-[O](examples/Hamby-44/Questioned//Bullet O.zip), 
-[P](examples/Hamby-44/Questioned//Bullet P.zip), 
-[S](examples/Hamby-44/Questioned//Bullet S.zip), 
-[T](examples/Hamby-44/Questioned//Bullet T.zip), 
-[U](examples/Hamby-44/Questioned//Bullet U.zip), 
-[X](examples/Hamby-44/Questioned//Bullet X.zip), 
-[Y](examples/Hamby-44/Questioned//Bullet Y.zip) 
+  - [Known Bullets 1 and 2 from Barrel 1](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/barrel%201.zip)
+  - Questioned bullets:  [E](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet E.zip), 
+  [F](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet F.zip), 
+[G](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet G.zip), 
+[H](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet H.zip), 
+[I](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet I.zip), 
+[J](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet J.zip), 
+[K](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet K.zip), 
+[L](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet L.zip), 
+[O](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet O.zip), 
+[P](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet P.zip), 
+[S](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet S.zip), 
+[T](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet T.zip), 
+[U](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet U.zip), 
+[X](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet X.zip), 
+[Y](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet Y.zip) 
 
 

--- a/README.md
+++ b/README.md
@@ -67,19 +67,20 @@ provided by CSAFE.
 Download:
 
 - [Known Bullets 1 and 2 from Barrel
-  1](examples/Hamby-44/barrel%201.zip)
-- Questioned bullets: [E](examples/Hamby-44/Questioned//Bullet%20E.zip),
-  [F](examples/Hamby-44/Questioned//Bullet%20F.zip),
-  [G](examples/Hamby-44/Questioned//Bullet%20G.zip),
-  [H](examples/Hamby-44/Questioned//Bullet%20H.zip),
-  [I](examples/Hamby-44/Questioned//Bullet%20I.zip),
-  [J](examples/Hamby-44/Questioned//Bullet%20J.zip),
-  [K](examples/Hamby-44/Questioned//Bullet%20K.zip),
-  [L](examples/Hamby-44/Questioned//Bullet%20L.zip),
-  [O](examples/Hamby-44/Questioned//Bullet%20O.zip),
-  [P](examples/Hamby-44/Questioned//Bullet%20P.zip),
-  [S](examples/Hamby-44/Questioned//Bullet%20S.zip),
-  [T](examples/Hamby-44/Questioned//Bullet%20T.zip),
-  [U](examples/Hamby-44/Questioned//Bullet%20U.zip),
-  [X](examples/Hamby-44/Questioned//Bullet%20X.zip),
-  [Y](examples/Hamby-44/Questioned//Bullet%20Y.zip)
+  1](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/barrel%201.zip)
+- Questioned bullets:
+  [E](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20E.zip),
+  [F](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20F.zip),
+  [G](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20G.zip),
+  [H](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20H.zip),
+  [I](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20I.zip),
+  [J](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20J.zip),
+  [K](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20K.zip),
+  [L](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20L.zip),
+  [O](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20O.zip),
+  [P](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20P.zip),
+  [S](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20S.zip),
+  [T](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20T.zip),
+  [U](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20U.zip),
+  [X](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20X.zip),
+  [Y](https://github.com/CSAFE-ISU/bulletAnalyzr/raw/main/examples/Hamby-44/Questioned//Bullet%20Y.zip)


### PR DESCRIPTION
Stacy asked me to pretend to be an end-user and install and test bulletAnalyzr. When I tried to download the example data from the README links, I noticed that clicking the first link to the known bullets downloads the zip file. But clicking the other links to example bullets navigates to the repo folder containing the examples instead of downloading the zip files. I updated these links in the README to download the zip files instead of navigating to the repo folder containing the example file.