### PR TITLE
38 stage click tabs

### DIFF
--- a/app/R/helper.R
+++ b/app/R/helper.R
@@ -79,6 +79,36 @@ identify_bullet <- function(words) {
   make.names(paste(samelist[[1]], collapse="")) # delete all forbidden characters
 }
 
+is_crosscut <- function(stages, strict = FALSE) {
+  return(is_stage(current = "crosscut", stages = stages, strict = strict))
+}
+
+is_groove <- function(stages, strict = FALSE) {
+  return(is_stage(current = "groove", stages = stages, strict = strict))
+}
+
+is_report <- function(stages, strict = FALSE) {
+  return(is_stage(current = "report", stages = stages, strict = strict))
+}
+
+is_stage <- function(current, stages, strict = FALSE) {
+
+  if (current %in% stages) {
+    if (strict && (current != stages[length(stages)])) {
+      return(FALSE)
+    } else {
+      return(TRUE)
+    }
+  } else {
+    return(FALSE)
+  }
+  
+}
+
+is_upload <- function(stages, strict = FALSE) {
+  return(is_stage(current = "upload", stages = stages, strict = strict))
+}
+
 make_export_df <- function(df) {
   # Modify data frame for export for testing. Drop the x3p column because it
   # makes the snapshots 100+ MB. Change source column from filepath to filename

--- a/app/server.R
+++ b/app/server.R
@@ -301,7 +301,7 @@ server <- function(input, output, session) {
     temp_refresh <- input$prevreport
     
     # Get selected bullet
-    bull <- fiter_preview_bullet(
+    bull <- filter_preview_bullet(
       allbull = bulldata$allbull,
       preview_bull_name = input$prev_bul
     )

--- a/app/server.R
+++ b/app/server.R
@@ -89,7 +89,7 @@ server <- function(input, output, session) {
   
   # BUTTON - Begin Button
   observeEvent(input$begin_button, {
-    bulldata$stage <- "upload"
+    bulldata$stage <- c("upload")
     updateTabsetPanel(session, "prevreport", selected = "Upload Bullet")
   })
   
@@ -98,7 +98,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Upload Land x3p Files Button
   output$bul_x3pui <- renderUI({
-    req(bulldata$stage == "upload")
+    req(is_upload(bulldata$stage))
     
     # Button - Bullet Land x3p Files
     fileInput("upload_button", "Select Bullet Land x3p files", accept = ".x3p", multiple = TRUE)
@@ -107,7 +107,7 @@ server <- function(input, output, session) {
   # OBSERVE EVENT - Bullet Land x3p Files Button
   # Preprocess uploaded x3p files and push to cbull
   observeEvent(input$upload_button, {
-    req(bulldata$stage == "upload")
+    req(is_upload(bulldata$stage))
     
     disable("add_to_list_button")
     
@@ -147,7 +147,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Display Lands on Upload Tab
   output$lpupload <- renderUI({
-    req(bulldata$stage == "upload")
+    req(is_upload(bulldata$stage))
     req(isTruthy(bulldata$cbull) || isTruthy(bulldata$cbull_name))
     
     progress <- shiny::Progress$new(); on.exit(progress$close())
@@ -199,7 +199,7 @@ server <- function(input, output, session) {
   # OBSERVE EVENT - Add Bullet to Comparison List button
   # Push current bullet data to all bullet data object
   observeEvent(input$add_to_list_button, {
-    req(bulldata$stage == "upload")
+    req(is_upload(bulldata$stage))
     req(bulldata$cbull)
     
     # Add bullet and land columns to current bullet
@@ -225,7 +225,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Select Bullets to Compare Checkbox
   output$bullSelCheckboxUI <- renderUI({
-    req(bulldata$stage == "upload")
+    req(is_upload(bulldata$stage))
     req(nrow(bulldata$allbull) > 0)
     
     # Store allbull
@@ -243,7 +243,7 @@ server <- function(input, output, session) {
   # OBSERVE EVENT - Compare Bullets button (Upload Bullet Tab) - Get default
   # crosscuts before starting interactivity
   observeEvent(input$doprocess, {
-    req(bulldata$stage == "upload")
+    req(is_upload(bulldata$stage))
     req(length(input$bull_sel_checkbox) > 0)
     
     values$show_alert <- FALSE
@@ -266,7 +266,7 @@ server <- function(input, output, session) {
     bulldata$postCC_export <- make_export_df(df = bulldata$postCC)
     
     # Switch to Comparison Report tab panel
-    bulldata$stage <- "crosscut"
+    bulldata$stage <- c("upload", "crosscut")
     updateTabsetPanel(session, "prevreport", selected = "Comparison Report")
   })
   
@@ -338,7 +338,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Crosscut Select Bullet Drop-down
   output$CCBull1 <- renderUI({
-    req(bulldata$stage == "crosscut")
+    req(is_crosscut(bulldata$stage))
     req(bulldata$preCC)
     
     # DROP-DOWN - Select Bullet
@@ -348,7 +348,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Crosscut Sliders, Finalize Button, and Compare Button
   output$CCBull2 <- renderUI({
-    req(bulldata$stage == "crosscut")
+    req(is_crosscut(bulldata$stage))
     req(bulldata$preCC)
     req(input$cc_bulsel)
     
@@ -372,7 +372,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Display Lands with Crosscuts
   output$CCBullLand <- 	renderUI({
-    req(bulldata$stage == "crosscut")
+    req(is_crosscut(bulldata$stage))
     req(bulldata$preCC)
     req(input$cc_bulsel)
     
@@ -411,7 +411,7 @@ server <- function(input, output, session) {
   # OBSERVE EVENT - Finalize Crosscut button
   # Update crosscut location in data frame with current crosscut slider values
   observeEvent(input$saveCC,{
-    req(bulldata$stage == "crosscut")
+    req(is_crosscut(bulldata$stage))
     req(bulldata$preCC)
     
     bullets <- bulldata$preCC
@@ -431,7 +431,7 @@ server <- function(input, output, session) {
   # OBSERVE EVENT - Compare Bullets Button
   # Push preCC to postCC and change stage to "grooves"
   observeEvent(input$doprocessCC,{
-    req(bulldata$stage == "crosscut")
+    req(is_crosscut(bulldata$stage))
     req(bulldata$preCC)
     
     progress <- shiny::Progress$new(); on.exit(progress$close())
@@ -450,7 +450,7 @@ server <- function(input, output, session) {
     bulldata$preCC <- NULL
     bulldata$preCC_export <- NULL
     
-    bulldata$stage <- "groove"
+    bulldata$stage <- c("upload", "crosscut", "groove")
   })
   
   
@@ -458,7 +458,7 @@ server <- function(input, output, session) {
   
   # REACTIVE - Filtered profile for grooves interactivity
   profile_df <- reactive({
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     req(input$groove_bulsel)
     req(input$groove_landsel)
@@ -473,7 +473,7 @@ server <- function(input, output, session) {
   
   # OBSERVE EVENT - Save Grooves
   observeEvent(input$save_grooves_button, {
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     req(input$groove_bulsel)
     req(input$groove_landsel)
@@ -495,7 +495,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Groove Select Bullet Drop-down
   output$grooveBullSelUI <- renderUI({
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     
     # DROP-DOWN - Select Bullet
@@ -505,7 +505,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Land Select Bullet Drop-down
   output$grooveLandSelUI <- renderUI({
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     
     # DROP-DOWN - Select Land
@@ -515,7 +515,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Groove Sliders
   output$grooveSlidersUI <- renderUI({
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     req(input$groove_bulsel)
     req(input$groove_landsel)
@@ -550,7 +550,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Save Grooves and Next Step Buttons
   output$groovesButtonsUI <- renderUI({
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     req(input$groove_bulsel)
     req(input$groove_landsel)
@@ -569,7 +569,7 @@ server <- function(input, output, session) {
   
   # PLOT OUTPUT - Render profiles with grooves
   output$profile_plot <- renderPlot({
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     req(input$groove_bulsel)
     req(input$groove_landsel)
@@ -587,7 +587,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Display Crosscut (Profiles) with Grooves
   output$groovePlotsUI <- 	renderUI({
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     req(input$groove_bulsel)
     
@@ -597,11 +597,11 @@ server <- function(input, output, session) {
   # OBSERVE EVENT - Next Step
   # Get signal, features, and random forest score, and bullet scores
   observeEvent(input$grooves_next_button, {
-    req(bulldata$stage == "groove")
+    req(is_groove(bulldata$stage, strict = TRUE))
     req(bulldata$postCC)
     req(bulldata$postCC$grooves)
     
-    bulldata$stage = "report"
+    bulldata$stage = c("upload", "crosscut", "groove", "report")
     updateTabsetPanel(session, "prevreport", selected = "Comparison Report")
     
     progress <- shiny::Progress$new(); on.exit(progress$close())
@@ -656,7 +656,7 @@ server <- function(input, output, session) {
   
   # OUTPUT UI - Report Comparison sidebar
   output$reportSelUI <- renderUI({
-    req(bulldata$stage == "report")
+    req(is_report(bulldata$stage))
     req(is.null(bulldata$preCC))
     req(bulldata$comparison)
     
@@ -682,7 +682,7 @@ server <- function(input, output, session) {
   # SECTION: PHASE TEST-----------------------------------------------
   
   observe({
-    req(bulldata$stage == "report")
+    req(is_report(bulldata$stage))
     req(bulldata$comparison)
     req(bulldata$comparison$bullet_scores)
     req(input$comp_bul1)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(bulletAnalyzr)
+
+test_check("bulletAnalyzr")

--- a/tests/testthat/test-helper.R
+++ b/tests/testthat/test-helper.R
@@ -1,0 +1,35 @@
+testthat::test_that("is stage works", {
+  # Expect TRUE when strict is TRUE - current is last item in stages
+  testthat::expect_true(is_stage(current = "upload", stages = c("upload"), strict = TRUE))
+  testthat::expect_true(is_stage(current = "crosscut", stages = c("upload", "crosscut"), strict = TRUE))
+  testthat::expect_true(is_stage(current = "report", stages = c("upload", "crosscut", "groove", "report"), strict = TRUE))
+  
+  # Expect FALSE when strict is TRUE - current item is not last item in stages
+  testthat::expect_false(is_stage(current = "upload", stages = c("upload", "crosscut"), strict = TRUE))
+  testthat::expect_false(is_stage(current = "crosscut", stages = c("upload"), strict = TRUE))
+  testthat::expect_false(is_stage(current = "crosscut", stages = c("upload", "crosscut", "groove", "report"), strict = TRUE))
+  
+  # Expect TRUE when strict is FALSE - current is somewhere in stages
+  testthat::expect_true(is_stage(current = "upload", stages = c("upload"), strict = FALSE))
+  testthat::expect_true(is_stage(current = "upload", stages = c("upload", "crosscut"), strict = FALSE))
+  testthat::expect_true(is_stage(current = "crosscut", stages = c("upload", "crosscut"), strict = FALSE))
+  testthat::expect_true(is_stage(current = "crosscut", stages = c("upload", "crosscut", "groove", "report"), strict = FALSE))
+  testthat::expect_true(is_stage(current = "report", stages = c("upload", "crosscut", "groove", "report"), strict = FALSE))
+  
+  # Expect FALSE when strict is FALSE - current isn't anywhere in stages
+  testthat::expect_false(is_stage(current = "crosscut", stages = c("upload"), strict = FALSE))
+  testthat::expect_false(is_stage(current = "groove", stages = c("upload", "crosscut"), strict = FALSE))
+  
+})
+
+testthat::test_that("is upload (stage) works", {
+  # Expect TRUE
+  testthat::expect_true(is_upload(stages = c("upload"), strict = TRUE))
+  testthat::expect_true(is_upload(stages = c("upload"), strict = FALSE))
+  testthat::expect_true(is_upload(stages = c("upload", "crosscut"), strict = FALSE))
+  
+  # Expect FALSE
+  testthat::expect_false(is_upload(stages = c("crosscut"), strict = FALSE))
+  testthat::expect_false(is_upload(stages = c("upload", "crosscut"), strict = TRUE))
+  testthat::expect_false(is_upload(stages = c("crosscut", "grooves"), strict = TRUE))
+})


### PR DESCRIPTION
Fixed problems with the upload and preview tabs not displaying correctly. 

## Updated stage tracking

Previously, the stage was tracked as a single string: "upload", "crosscut", "groove", or "report". This causes a problem if the user is on the report stage and wants to go back to the upload tab because the stage is no longer upload. I tried implementing an observeEvent statement to change the stage if the use clicked a tab, but this created new problems. 

As a solution, I changed the stage so that it is tracked as a vector of strings. The newest stage is appended to the vector. The `req()` statements now check whether a particular stage is in the vector. I added new helper functions `is_crosscut()`, `is_groove()`, `is_report()`, `is_upload()`. These functions all call another new helper `is_stage()`. 

The groove functionality only appears if "groove" is the last item in the stage vector. This is accomplished with strict = TRUE in `is_stage()`. If "report" is in the vector after "groove" and strict is FALSE in `is_stage()`, both the groove and report functionality will appear on the report tab.

## Fixed typo on preview tab

The preview tab mistakenly tried to call `fiter_preview_bullet()`. The tab now correctly calls `filter_preview_bullet()`