### PR TITLE
fix: number lands sequentially

### DIFF
--- a/app/R/helper.R
+++ b/app/R/helper.R
@@ -47,22 +47,6 @@ get_rf_order <- function(bsldata) {
   return(order(bsldata$rfscore, decreasing = TRUE))
 }
 
-identify_lands <- function(words) {
-  # create a list of distinguishing elements between names
-  
-  if (length(words) == 1) return(1)
-
-  # split each word by character and transpose  
-  list <- strsplit(words, split="")
-  tlist <- purrr::list_transpose(list)
-  # toss out everything that matches
-  difflist <- tlist %>% purrr::map(.f = function(l) { if (length(unique(l)) > 1) return(l); NULL})
-  difflist <- purrr::discard(difflist, is.null) 
-  # transpose back and make 'word'
-  difflist <- difflist %>% purrr::list_transpose() %>% purrr::map_chr(paste, collapse="")
-  make.unique(difflist) # make sure that something is there and it is different
-}
-
 identify_bullet <- function(words) {
   # create a list of the same elements between names
   if (length(words) == 1) return(words)

--- a/app/R/preprocess.R
+++ b/app/R/preprocess.R
@@ -73,7 +73,7 @@ preprocess_bullet <- function(allbull, cbull, show_alert, progress, session) {
   
   # Get names
   cbull$filename <- basename(cbull$source)
-  cbull$land_names <- identify_lands(cbull$filename)
+  cbull$land_names <- as.character(1:nrow(cbull))
   cbull$bullet_name <- identify_bullet(cbull$filename)
   
   return(list(allbull = allbull, cbull = cbull))


### PR DESCRIPTION
Previously, land names were assigned with the function `identify_lands()` look at the filenames for a bullet's lands. Starting at the beginning of the filenames, words that are present in all 6 filenames would be dropped. After finding a word that is not the same in all 6 filenames, the remaining parts of the filenames are returned as the land names. This resulted in unexpected land names for some files.

Now land names are simply numbered 1, 2, 3, 4, 5, 6. The numbers are stored as characters as before.