### PR TITLE
fix: fail with helpful error message if crosscut is NA

### DIFF
--- a/app/R/process-wrappers.R
+++ b/app/R/process-wrappers.R
@@ -42,7 +42,17 @@ get_ccdata_wrapper <- function(postCC, progress = NULL) {
 }
 
 get_default_cc_wrapper <- function(bullets, interactive_cc, ylimits = c(150, NA)) {
+  
   bullets$crosscut <- sapply(bullets$x3p, x3p_crosscut_optimize, ylimits = ylimits)
+  
+  # Check for NA values
+  na_idx <- is.na(bullets$crosscut)
+  if (any(na_idx)) {
+    bullet_land <- paste("Bullet", bullets$bullet, "Land", bullets$land)
+    
+    stop(paste("x3p_crosscut_optimize could not find a stable region in land:", 
+            paste(bullet_land[na_idx], collapse = ", ")))
+  }
   
   # Store bullets as preCC or postCC ----
   if(interactive_cc) {


### PR DESCRIPTION
If `x3p_crosscut_optimize()` can't find a stable region in a land, it returns NA for the crosscut location. If the app continues, the crosscut slider will return an error message that the value cannot be NA. I need to talk with Heike to figure out proper treatment of lands without stable regions.

In the meantime, I added a check for NA values in `get_default_cc_wrapper()`. If any NA values are present, the app stops and returns a list of the bullet name and land name(s) that had NA values. The current statistical model cannot handle missing lands, so allowing users to proceed with the comparison could lead to wildly incorrect results.