### PR TITLE
feat: add download data button to comparison report page

### DIFF
--- a/app/R/download-data-module.R
+++ b/app/R/download-data-module.R
@@ -1,0 +1,43 @@
+downloadDataUI <- function(id) {
+  ns <- NS(id)
+  downloadButton(ns("download_data_button"), "Download Data")
+}
+
+downloadDataServer <- function(id, bullet_data = NULL, drop_x3p = TRUE) {
+  moduleServer(id, function(input, output, session) {
+    
+    # Prep data for download
+    download_data <- reactive({
+      req(bullet_data)
+      data <- reactiveValuesToList(bullet_data)
+      
+      if (drop_x3p) {
+        data$allbull <- NULL
+        data$cbull <- NULL
+        data$preCC <- NULL
+        data$postCC <- NULL
+        data$comparison <- NULL
+      } else {
+        data$allbull_export <- NULL
+        data$cbull_export <- NULL
+        data$preCC_export <- NULL
+        data$postCC_export <- NULL
+        data$comparison_export <- NULL
+      }
+
+      return(data)
+    })
+    
+    # Data download handler
+    output$download_data_button <- downloadHandler(
+      filename = function() {
+        paste0("bullet-comparison-data-", Sys.Date(), ".rds")
+      },
+      content = function(file) {
+        saveRDS(download_data(), file)
+      },
+      contentType = "application/rds"
+    )
+    
+  })
+}

--- a/app/R/report-module.R
+++ b/app/R/report-module.R
@@ -188,8 +188,14 @@ reportServer <- function(id, bullet_data = NULL, comp_bul1 = NULL, comp_bul2 = N
       req(bullet_data$comparison)
       
       # BUTTON - Download Report ----
-      fluidRow(column(12, screenshotButton(label = "Download Report", id = session$ns("report"), filename="Bullet Comparison Report", scale = 2), align="center"))
+      htmltools::tagList(
+        fluidRow(column(12, screenshotButton(label = "Download Report", id = session$ns("report"), filename="Bullet Comparison Report", scale = 2), align="center")),
+        br(),
+        fluidRow(column(12, downloadDataUI(session$ns("data1"))), align = "center")
+      )
     })
+    
+    downloadDataServer("data1", bullet_data = bullet_data, drop_x3p = TRUE)
     
     # OUTPUT - Phase test score ----
     output$bull_comp_score <- renderText({

--- a/app/server.R
+++ b/app/server.R
@@ -33,6 +33,7 @@ sample_m = 10
 
 # Helper Functions
 source("R/bullet-lists.R")
+source("R/download-data-module.R")
 source("R/helper.R")
 source("R/plot.R")
 source("R/preprocess.R")


### PR DESCRIPTION
Created `downloadDataUI()` and `downloadDataServer()` to save reactive values in `bullet_data` as a list in an RDS file. The server function has an option `drop_x3p` to drop the x3p columns from the data frames to make the RDS file smaller.