### PR TITLE
refactor: centralize study path resolution and update comparison scripts

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -8,7 +8,6 @@ Because these scripts are not intended for end users, they are not located withi
 
 | Script | Description |
 |--------|-------------|
-| `align-two-lands.R` | Aligns two bullet land signals and calculates comparison features (CCF, striation marks, etc.). Supports optional groove CSV files. Also, compares all pairs of lands for a single bullet by calculating features and plotting aligned signal pairs. |
 | `bullet-codes.R` | Extracts standardized bullet codes from scan filenames and filepaths across datasets (Hamby, Houston, CTS, DFSC, Phoenix, etc.). |
 | `bullet-scan-rotation-script.R` | Rotates all x3p scans in a directory by a specified angle (default 90°). |
 | `dat-to-x3p.R` | Reads space-delimited `.dat` files from a directory and converts each into an x3p object. |
@@ -26,8 +25,11 @@ Because these scripts are not intended for end users, they are not located withi
 
 | Script | Description |
 |--------|-------------|
+| `align-signals.R` | Aligns two bullet land signals and calculates comparison features (CCF, striation marks, etc.). Supports optional groove CSV files. Includes `align_all_land_pairs()` to compare all lands of a single bullet and `plot_alignment_matrix()` to visualize results in a 6x6 grid. |
 | `analyze-houston-comparisons.R` | Analyzes Houston bullet study comparison scores and generates plots replicating Vanderplas et al. 2020 Figure 6. |
-| `auto-bullet-comparison-pipeline.R` | Automated end-to-end pipeline comparing two bullets. |
+| `auto-bullet-comparison-pipeline.R` | Automated end-to-end pipeline comparing two bullets with automatic crosscut and groove detection. |
 | `compare-example-hamby44.R` | Example showing how to run the manual comparison pipeline on Hamby Set 44 scans. |
-| `compare-houston.R` | Compares all bullet pairs from the Houston Set Final dataset. |
-| `manual-bullet-comparison-pipeline.R` | Interactive pipeline comparing two bullets using manually-specified groove locations from CSV files, with parallel processing support. |
+| `compare-houston.R` | Batch comparison script for the Houston Set Final dataset. Generates all pairwise bullet comparisons. |
+| `compare-phoenix.R` | Batch comparison script for the Phoenix Test dataset. Generates all pairwise bullet comparisons. |
+| `comparison-utils.R` | Shared helper functions for comparison pipelines (e.g., `cond_x3p_m_to_mum`, `make_pairs_df`, `make_outfile`, `extract_signals`, `align_signals`, `extract_features`, `calculate_rf_scores`, `calculate_bullet_scores`, `run_phase_test`). |
+| `manual-bullet-comparison-pipeline.R` | Pipeline comparing two bullets using manually-specified groove locations from CSV files, with parallel processing support. |

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -29,7 +29,8 @@ Because these scripts are not intended for end users, they are not located withi
 | `analyze-houston-comparisons.R` | Analyzes Houston bullet study comparison scores and generates plots replicating Vanderplas et al. 2020 Figure 6. |
 | `auto-bullet-comparison-pipeline.R` | Automated end-to-end pipeline comparing two bullets with automatic crosscut and groove detection. |
 | `compare-example-hamby44.R` | Example showing how to run the manual comparison pipeline on Hamby Set 44 scans. |
+| `compare-hamby44.R` | Batch comparison script for the Hamby Set 44 Final dataset. Generates all pairwise bullet comparisons (known and unknown) using the manual pipeline with parallel processing. |
 | `compare-houston.R` | Batch comparison script for the Houston Set Final dataset. Generates all pairwise bullet comparisons. |
 | `compare-phoenix.R` | Batch comparison script for the Phoenix Test dataset. Generates all pairwise bullet comparisons. |
-| `comparison-utils.R` | Shared helper functions for comparison pipelines (e.g., `cond_x3p_m_to_mum`, `make_pairs_df`, `make_outfile`, `extract_signals`, `align_signals`, `extract_features`, `calculate_rf_scores`, `calculate_bullet_scores`, `run_phase_test`). |
+| `comparison-utils.R` | Shared helper functions for comparison pipelines (e.g., `get_study_path`, `cond_x3p_m_to_mum`, `make_pairs_df`, `make_outfile`, `extract_signals`, `align_signals`, `extract_features`, `calculate_rf_scores`, `calculate_bullet_scores`, `run_phase_test`). |
 | `manual-bullet-comparison-pipeline.R` | Pipeline comparing two bullets using manually-specified groove locations from CSV files, with parallel processing support. |

--- a/docs/developers/comparisons/analyze-houston-comparisons.R
+++ b/docs/developers/comparisons/analyze-houston-comparisons.R
@@ -14,35 +14,9 @@
 library(dplyr)
 library(ggplot2)
 source("docs/developers/bullet-codes.R")
-
+source("docs/developers/comparisons/comparison-utils.R")
 
 # Helper Functions --------------------------------------------------------
-
-get_bullet_scores_df <- function(houston_dir) {
-  # Load files into single data frame
-  files <- list.files(file.path(houston_dir, "comparisons"), pattern = "\\.rds", full.names = TRUE)
-  df <- lapply(files, function(f) {
-    df <- readRDS(f)
-    return(df$bullet_scores)
-  })
-  df <- do.call(rbind, df)
-  
-  # Extract group, barrel, and bullet from bullet names
-  df <- cbind(df, parse_bullet_codes(df$bulletA, suffix = "1"))
-  df <- cbind(df, parse_bullet_codes(df$bulletB, suffix = "2"))
-  
-  return(df)
-}
-
-if (dir.exists("/Volumes/T7_Shield/CSAFE/datasets/bullet_datasets/Houston Set Final")) {
-  houston_dir <- "/Volumes/T7_Shield/CSAFE/datasets/bullet_datasets/Houston Set Final"
-} else if (dir.exists("/Volumes/research/csafe-firearms/bullet-scans/Houston Set Final")) {
-  houston_dir <- "/Volumes/research/csafe-firearms/bullet-scans/Houston Set Final"
-} else if (dir.exists("/Volumes/lss/research/csafe-firearms/bullet-scans/Houston Set Final")) {
-  houston_dir <- "/Volumes/lss/research/csafe-firearms/bullet-scans/Houston Set Final"
-} else {
-  stop("Are you connected to LSS?")
-}
 
 #' Replicate the Plot in Figure 6 in Vanderplas et al. 2020
 #'
@@ -198,8 +172,9 @@ save_plot <- function(p, outfile, width, height) {
 
 # Analyze Bullet Scores ---------------------------------------------------
 
-df <- get_bullet_scores_df(houston_dir)
-write.csv(df, file.path(houston_dir, "comparisons", "bullet-to-bullet-scores.csv"))
+study_dir <- get_study_path(study = "Houston Set Final")
+
+df <- read.csv(file.path(study_dir, "Comparisons", "bullet-to-bullet-scores.csv"))
 
 # Group 1 ----
 
@@ -214,7 +189,7 @@ plot_fig6(
   group = 1,
   title = "Houston Set 1",
   subtitle = "Known Versus Unknown Bullets",
-  outfile = file.path(houston_dir, "plots", "houston1_kvu.png"),
+  outfile = file.path(study_dir, "plots", "houston1_kvu.png"),
   width = 10,
   height = 5
 )
@@ -232,7 +207,7 @@ plot_fig6(
   group = 2,
   title = "Houston Set 2",
   subtitle = "Known Versus Unknown Bullets",
-  outfile = file.path(houston_dir, "plots", "houston2_kvu.png"),
+  outfile = file.path(study_dir, "plots", "houston2_kvu.png"),
   width = 10,
   height = 5
 )
@@ -250,7 +225,7 @@ plot_fig6(
   group = 3,
   title = "Houston Set 3",
   subtitle = "Known Versus Unknown Bullets",
-  outfile = file.path(houston_dir, "plots", "houston3_kvu.png"),
+  outfile = file.path(study_dir, "plots", "houston3_kvu.png"),
   width = 10,
   height = 5
 )

--- a/docs/developers/comparisons/compare-hamby44.R
+++ b/docs/developers/comparisons/compare-hamby44.R
@@ -1,15 +1,15 @@
-# Compare Phoenix Test
+# Compare Hamby Set 44 Final
 #
-# Batch comparison script for the Phoenix Test bullet dataset. Generates
+# Batch comparison script for the Hamby Set 44 Final bullet dataset. Generates
 # all pairwise bullet combinations (known and unknown), then runs the manual
 # comparison pipeline on each pair using parallel processing (4 cores).
 # Results are saved as individual RDS files in the dataset's comparisons/
 # directory.
 #
-# Requires the Phoenix Test dataset on an external drive or LSS.
+# Requires the Hamby Set 44 Final dataset on an external drive or LSS.
 #
 # Usage:
-#   source("docs/developers/comparisons/compare-phoenix.R")
+#   source("docs/developers/comparisons/compare-hamby44.R")
 
 source("inst/scripts/manual_groove_selection.R")
 source("docs/developers/comparisons/comparison-utils.R")
@@ -45,11 +45,12 @@ list_bullets <- function(main_dir) {
   dirs <- list.dirs(main_dir, recursive = FALSE)
 
   # Get known bullets
-  kbarrels <- dirs[startsWith(basename(dirs), "Gun")]
+  kbarrels <- dirs[startsWith(basename(dirs), "Barrel")]
   kbullets <- unlist(lapply(kbarrels, function(d) list.dirs(d, recursive = FALSE)))
 
   # Get unknown bullets
-  ubullets <- dirs[startsWith(basename(dirs), "Unknown")]
+  ubarrels <- dirs[basename(dirs) == "Unknowns"]
+  ubullets <- list.dirs(ubarrels, recursive = FALSE)
 
   bullets <- c(kbullets, ubullets)
 
@@ -59,15 +60,29 @@ list_bullets <- function(main_dir) {
 
 # Setup -------------------------------------------------------------------
 
-study_dir <- get_study_path(study = "Phoenix Test")
+study <- "Hamby Set 44 Final"
+
+local_dir <- file.path("/Volumes/T7_Shield/CSAFE/datasets/bullet_datasets", study)
+lss1 <- file.path("/Volumes/research/csafe-firearms/bullet-scans", study)
+lss2 <- file.path("/Volumes/lss/research/csafe-firearms/bullet-scans", study)
+
+if (dir.exists(local_dir)) {
+  study_dir <- local_dir
+} else if (dir.exists(lss1)) {
+  study_dir <- lss1
+} else if (dir.exists(lss2)) {
+  study_dir <- lss2
+} else {
+  stop("Are you connected to LSS or the external drive?")
+}
 
 bullets <- list_bullets(main_dir = study_dir)
 
 
 # Manually Detect Grooves -------------------------------------------------
 
-for (bullet in bullets[32:34]) {
-  result <- process_directory(
+for (bullet in bullets[3:35]) {
+  process_directory(
     bullet,
     file.path(bullet, "grooves.csv")
   )
@@ -81,7 +96,7 @@ for (i in 1:nrow(pairs)) {
   compare_bullets(
     bullet1_dir = pairs$bullet1[i],
     bullet2_dir = pairs$bullet2[i],
-    outfile = make_outfile(file.path(study_dir, "Comparisons"), pairs$bullet1_name[i], pairs$bullet2_name[i]),
+    outfile = make_outfile(file.path(study_dir, "comparisons"), pairs$bullet1_name[i], pairs$bullet2_name[i]),
     cores = 4
   )
 }

--- a/docs/developers/comparisons/compare-hamby44.R
+++ b/docs/developers/comparisons/compare-hamby44.R
@@ -15,6 +15,7 @@ source("inst/scripts/manual_groove_selection.R")
 source("docs/developers/comparisons/comparison-utils.R")
 source("docs/developers/comparisons/manual-bullet-comparison-pipeline.R")
 source("docs/developers/bullet-codes.R")
+source("docs/developers/view-pipeline.R")
 
 
 # Helper Functions --------------------------------------------------------
@@ -61,32 +62,19 @@ list_bullets <- function(main_dir) {
 # Setup -------------------------------------------------------------------
 
 study <- "Hamby Set 44 Final"
-
-local_dir <- file.path("/Volumes/T7_Shield/CSAFE/datasets/bullet_datasets", study)
-lss1 <- file.path("/Volumes/research/csafe-firearms/bullet-scans", study)
-lss2 <- file.path("/Volumes/lss/research/csafe-firearms/bullet-scans", study)
-
-if (dir.exists(local_dir)) {
-  study_dir <- local_dir
-} else if (dir.exists(lss1)) {
-  study_dir <- lss1
-} else if (dir.exists(lss2)) {
-  study_dir <- lss2
-} else {
-  stop("Are you connected to LSS or the external drive?")
-}
+study_dir <- get_study_path(study = study)
 
 bullets <- list_bullets(main_dir = study_dir)
 
-
 # Manually Detect Grooves -------------------------------------------------
 
-for (bullet in bullets[3:35]) {
+for (bullet in bullets) {
   process_directory(
     bullet,
     file.path(bullet, "grooves.csv")
   )
 }
+
 
 # Compare Bullets ---------------------------------------------------------
 

--- a/docs/developers/comparisons/compare-hamby44.R
+++ b/docs/developers/comparisons/compare-hamby44.R
@@ -20,27 +20,6 @@ source("docs/developers/view-pipeline.R")
 
 # Helper Functions --------------------------------------------------------
 
-get_unknown_bullets <- function(groups) {
-  # List unknown barrels from all groups
-  ubarrel1 <- list.dirs(groups[1], recursive = FALSE)
-  ubarrel1 <- ubarrel1[!startsWith(basename(ubarrel1), "K")]
-  ubarrel2 <- list.dirs(groups[2], recursive = FALSE)
-  ubarrel2 <- ubarrel2[!startsWith(basename(ubarrel2), "K")]
-  ubarrel3 <- list.dirs(groups[3], recursive = FALSE)
-  ubarrel3 <- ubarrel3[!startsWith(basename(ubarrel3), "K")]
-  ubarrels <- c(ubarrel1, ubarrel2, ubarrel3)
-
-  ubullets <- list.dirs(ubarrels, recursive = FALSE)
-
-  # Remove duplicate bullet - U36 is in group 1 and group 3
-  ubullets <- ubullets[!duplicated(basename(ubullets))]
-
-  # Sort by bullet number across all groups
-  ubullets <- ubullets[order(basename(ubullets))]
-
-  return(ubullets)
-}
-
 list_bullets <- function(main_dir) {
   # List bullet directories
   dirs <- list.dirs(main_dir, recursive = FALSE)
@@ -68,12 +47,12 @@ bullets <- list_bullets(main_dir = study_dir)
 
 # Manually Detect Grooves -------------------------------------------------
 
-for (bullet in bullets) {
-  process_directory(
-    bullet,
-    file.path(bullet, "grooves.csv")
-  )
-}
+# for (bullet in bullets) {
+#   process_directory(
+#     bullet,
+#     file.path(bullet, "grooves.csv")
+#   )
+# }
 
 
 # Compare Bullets ---------------------------------------------------------
@@ -84,7 +63,7 @@ for (i in 1:nrow(pairs)) {
   compare_bullets(
     bullet1_dir = pairs$bullet1[i],
     bullet2_dir = pairs$bullet2[i],
-    outfile = make_outfile(file.path(study_dir, "comparisons"), pairs$bullet1_name[i], pairs$bullet2_name[i]),
+    outfile = make_outfile(file.path(study_dir, "Comparisons"), pairs$bullet1_name[i], pairs$bullet2_name[i]),
     cores = 4
   )
 }

--- a/docs/developers/comparisons/compare-houston.R
+++ b/docs/developers/comparisons/compare-houston.R
@@ -52,10 +52,6 @@ get_unknown_bullets <- function(groups) {
   return(ubullets)
 }
 
-get_unknown_barrels <- function(groups) {
-  # List unknown barrels - KA, KB,..., KJ - from all groups
-}
-
 list_bullets <- function(main_dir) {
   # List bullet directories
   groups <- list.dirs(main_dir, recursive = FALSE)
@@ -90,3 +86,10 @@ for (i in 1:nrow(pairs)) {
     cores = 4
   )
 }
+
+
+# Make Bullet-to-bullet Scores Dataframe ----------------------------------
+
+df <- get_bullet_scores_df(houston_dir)
+write.csv(df, file.path(houston_dir, "Comparisons", "bullet-to-bullet-scores.csv"))
+

--- a/docs/developers/comparisons/compare-phoenix.R
+++ b/docs/developers/comparisons/compare-phoenix.R
@@ -19,27 +19,6 @@ source("docs/developers/bullet-codes.R")
 
 # Helper Functions --------------------------------------------------------
 
-get_unknown_bullets <- function(groups) {
-  # List unknown barrels from all groups
-  ubarrel1 <- list.dirs(groups[1], recursive = FALSE)
-  ubarrel1 <- ubarrel1[!startsWith(basename(ubarrel1), "K")]
-  ubarrel2 <- list.dirs(groups[2], recursive = FALSE)
-  ubarrel2 <- ubarrel2[!startsWith(basename(ubarrel2), "K")]
-  ubarrel3 <- list.dirs(groups[3], recursive = FALSE)
-  ubarrel3 <- ubarrel3[!startsWith(basename(ubarrel3), "K")]
-  ubarrels <- c(ubarrel1, ubarrel2, ubarrel3)
-
-  ubullets <- list.dirs(ubarrels, recursive = FALSE)
-
-  # Remove duplicate bullet - U36 is in group 1 and group 3
-  ubullets <- ubullets[!duplicated(basename(ubullets))]
-
-  # Sort by bullet number across all groups
-  ubullets <- ubullets[order(basename(ubullets))]
-
-  return(ubullets)
-}
-
 list_bullets <- function(main_dir) {
   # List bullet directories
   dirs <- list.dirs(main_dir, recursive = FALSE)
@@ -66,12 +45,12 @@ bullets <- list_bullets(main_dir = study_dir)
 
 # Manually Detect Grooves -------------------------------------------------
 
-for (bullet in bullets[32:34]) {
-  result <- process_directory(
-    bullet,
-    file.path(bullet, "grooves.csv")
-  )
-}
+# for (bullet in bullets[32:34]) {
+#   result <- process_directory(
+#     bullet,
+#     file.path(bullet, "grooves.csv")
+#   )
+# }
 
 # Compare Bullets ---------------------------------------------------------
 

--- a/docs/developers/comparisons/comparison-utils.R
+++ b/docs/developers/comparisons/comparison-utils.R
@@ -6,6 +6,31 @@
 # Usage:
 #   source("docs/developers/comparisons/comparison-utils.R")
 
+
+# Storage Paths -----------------------------------------------------------
+
+get_study_path <- function(
+    study, 
+    extdrive = "/Volumes/T7_Shield/CSAFE/datasets/bullet_datasets",
+    lss1 = "/Volumes/research/csafe-firearms/bullet-scans",
+    lss2 = "/Volumes/lss/research/csafe-firearms/bullet-scans"
+) {
+  local_dir <- file.path(extdrive, study)
+  lss1 <- file.path(lss1, study)
+  lss2 <- file.path(lss2, study)
+  
+  if (dir.exists(local_dir)) {
+    study_dir <- local_dir
+  } else if (dir.exists(lss1)) {
+    study_dir <- lss1
+  } else if (dir.exists(lss2)) {
+    study_dir <- lss2
+  } else {
+    stop("Are you connected to LSS or the external drive?")
+  }
+  return(study_dir)
+}
+
 # Unit Conversion ---------------------------------------------------------
 
 #' Conditionally Convert x3p from Meters to Micrometers
@@ -43,17 +68,17 @@ rotate_bullet_if_needed <- function(bullet) {
 #' @returns Preprocessed bullet data frame
 preprocess_bullet_standalone <- function(bullet, bullet_name) {
   cat("Preprocessing bullet:", bullet_name, "\n")
-
+  
   # Rotate if needed
   bullet <- rotate_bullet_if_needed(bullet)
-
+  
   # Convert to microns if needed
   bullet$x3p <- lapply(bullet$x3p, cond_x3p_m_to_mum)
-
+  
   # Add metadata
   bullet$bullet <- bullet_name
   bullet$land <- seq_len(nrow(bullet))
-
+  
   return(bullet)
 }
 
@@ -65,7 +90,7 @@ preprocess_bullet_standalone <- function(bullet, bullet_name) {
 #' @returns Data frame with sigs column added
 extract_signals <- function(bullets) {
   cat("Extracting signals...\n")
-
+  
   bullets$sigs <- mapply(
     function(ccdata, grooves) {
       bulletxtrctr::cc_get_signature(ccdata, grooves, span1 = 0.75, span2 = 0.03)
@@ -74,7 +99,7 @@ extract_signals <- function(bullets) {
     bullets$grooves,
     SIMPLIFY = FALSE
   )
-
+  
   return(bullets)
 }
 
@@ -83,15 +108,15 @@ extract_signals <- function(bullets) {
 #' @returns List with bullets and comparisons data frames
 align_signals <- function(bullets) {
   cat("Aligning signals between all land pairs...\n")
-
+  
   bullets$bulletland <- paste0(bullets$bullet, "-", bullets$land)
   lands <- unique(bullets$bulletland)
-
+  
   comparisons <- data.frame(
     expand.grid(land1 = lands, land2 = lands),
     stringsAsFactors = FALSE
   )
-
+  
   comparisons$aligned <- mapply(
     function(x, y) {
       bulletxtrctr::sig_align(
@@ -103,9 +128,9 @@ align_signals <- function(bullets) {
     comparisons$land2,
     SIMPLIFY = FALSE
   )
-
+  
   cat("  Created", nrow(comparisons), "land-to-land comparisons\n")
-
+  
   return(list(bullets = bullets, comparisons = comparisons))
 }
 
@@ -118,21 +143,21 @@ align_signals <- function(bullets) {
 #' @returns List with comparisons and features data frames
 extract_features <- function(comparisons, resolution) {
   cat("Extracting features...\n")
-
+  
   # Calculate CCF
   cat("  Calculating cross-correlation...\n")
   comparisons$ccf0 <- sapply(comparisons$aligned, function(x) bulletxtrctr::extract_feature_ccf(x$lands))
-
+  
   # Evaluate striation marks
   cat("  Evaluating striation marks...\n")
   comparisons$striae <- lapply(comparisons$aligned, bulletxtrctr::sig_cms_max, span = 75)
-
+  
   # Extract bullet/land identifiers
   comparisons$bulletA <- sapply(strsplit(as.character(comparisons$land1), "-"), "[[", 1)
   comparisons$bulletB <- sapply(strsplit(as.character(comparisons$land2), "-"), "[[", 1)
   comparisons$landA <- sapply(strsplit(as.character(comparisons$land1), "-"), "[[", 2)
   comparisons$landB <- sapply(strsplit(as.character(comparisons$land2), "-"), "[[", 2)
-
+  
   # Extract all features
   cat("  Extracting all features...\n")
   comparisons$features <- mapply(
@@ -142,13 +167,13 @@ extract_features <- function(comparisons, resolution) {
     MoreArgs = list(resolution = resolution),
     SIMPLIFY = FALSE
   )
-
+  
   # Unnest and scale features
   features <- tidyr::unnest(
     comparisons[, c("land1", "land2", "ccf0", "bulletA", "bulletB", "landA", "landB", "features")],
     cols = features
   )
-
+  
   features <- features %>%
     dplyr::mutate(
       cms = cms_per_mm,
@@ -156,7 +181,7 @@ extract_features <- function(comparisons, resolution) {
       mismatches = mismatches_per_mm,
       non_cms = non_cms_per_mm
     )
-
+  
   return(list(comparisons = comparisons, features = features))
 }
 
@@ -168,9 +193,9 @@ extract_features <- function(comparisons, resolution) {
 #' @returns Data frame with rfscore column added
 calculate_rf_scores <- function(features) {
   cat("Calculating random forest scores...\n")
-
+  
   features$rfscore <- predict(bulletxtrctr::rtrees, newdata = features, type = "prob")[, 2]
-
+  
   return(features)
 }
 
@@ -179,11 +204,11 @@ calculate_rf_scores <- function(features) {
 #' @returns Data frame with bullet scores
 calculate_bullet_scores <- function(features) {
   cat("Calculating bullet-level scores...\n")
-
+  
   bullet_scores <- features %>%
     dplyr::group_by(bulletA, bulletB) %>%
     tidyr::nest()
-
+  
   bullet_scores$bullet_score <- sapply(
     bullet_scores$data,
     function(d) {
@@ -197,7 +222,7 @@ calculate_bullet_scores <- function(features) {
       return(max(avgs$scores))
     }
   )
-
+  
   return(bullet_scores)
 }
 
@@ -211,23 +236,23 @@ calculate_bullet_scores <- function(features) {
 #' @returns Phase test results
 run_phase_test <- function(features, bulletA, bulletB) {
   cat("Running phase test...\n")
-
+  
   # Filter to just the comparison between the two different bullets
   comparison_data <- features %>%
     dplyr::filter(
       (features$bulletA == bulletA & features$bulletB == bulletB) |
         (features$bulletA == bulletB & features$bulletB == bulletA)
     )
-
+  
   if (nrow(comparison_data) == 0) {
     warning("No comparison data found between the two bullets")
     return(NULL)
   }
-
+  
   # Get the A vs B comparison (not B vs A to avoid duplication)
   comparison_data <- comparison_data %>%
     dplyr::filter(bulletA == !!bulletA & bulletB == !!bulletB)
-
+  
   # Run phase test using CCF scores (same as bulletAnalyzrApp)
   result <- tryCatch(
     {
@@ -236,24 +261,24 @@ run_phase_test <- function(features, bulletA, bulletB) {
         land2 = comparison_data$landB,
         score = comparison_data$ccf
       )
-
+      
       df <- df %>%
         dplyr::mutate(phase = bulletxtrctr::get_phases(land1, land2))
-
+      
       n <- max(df$phase)
       avgs <- df %>%
         dplyr::group_by(phase) %>%
         dplyr::summarize(means = mean(score, na.rm = TRUE)) %>%
         dplyr::arrange(means)
-
+      
       est1 <- avgs$means[n]
       est2 <- avgs$means[floor(n / 2)]
-
+      
       # Calculate pooled variance
       df_labeled <- df %>%
         dplyr::left_join(avgs %>% dplyr::mutate(ordered = dplyr::row_number()), by = "phase") %>%
         dplyr::mutate(inphase = ordered == n)
-
+      
       sigmas <- df_labeled %>%
         dplyr::group_by(inphase) %>%
         dplyr::summarize(
@@ -262,12 +287,12 @@ run_phase_test <- function(features, bulletA, bulletB) {
         ) %>%
         dplyr::ungroup() %>%
         dplyr::summarize(pooled = sum(nu * sd) / sum(nu))
-
+      
       sigma_0 <- sigmas$pooled[1]
-
+      
       test_statistic <- est1 - est2
       p_value <- bulletxtrctr::F_T(test_statistic, sigma = sigma_0, n = n, lower.tail = FALSE)
-
+      
       # Return same structure as bulletAnalyzrApp
       res <- list(
         estimate = est1 - est2,
@@ -287,7 +312,7 @@ run_phase_test <- function(features, bulletA, bulletB) {
       return(NULL)
     }
   )
-
+  
   return(result)
 }
 

--- a/docs/developers/comparisons/comparison-utils.R
+++ b/docs/developers/comparisons/comparison-utils.R
@@ -338,3 +338,22 @@ make_pairs_df <- function(bullets) {
 make_outfile <- function(outdir, bullet1_name, bullet2_name) {
   return(file.path(outdir, paste0(bullet1_name, "_", bullet2_name, ".rds")))
 }
+
+
+# Results -----------------------------------------------------------------
+
+get_bullet_scores_df <- function(study_dir) {
+  # Load files into single data frame
+  files <- list.files(file.path(study_dir, "Comparisons"), pattern = "\\.rds", full.names = TRUE)
+  df <- lapply(files, function(f) {
+    df <- readRDS(f)
+    return(df$bullet_scores)
+  })
+  df <- do.call(rbind, df)
+  
+  # Extract group, barrel, and bullet from bullet names
+  df <- cbind(df, parse_bullet_codes(df$bulletA, suffix = "1"))
+  df <- cbind(df, parse_bullet_codes(df$bulletB, suffix = "2"))
+  
+  return(df)
+}

--- a/docs/developers/comparisons/manual-bullet-comparison-pipeline.R
+++ b/docs/developers/comparisons/manual-bullet-comparison-pipeline.R
@@ -640,6 +640,9 @@ compare_bullets <- function(bullet1_dir, bullet2_dir, outfile = NULL,
 
   # Save to RDS file if outfile is specified
   if (!is.null(outfile)) {
+    if (!dir.exists(dirname(outfile))) {
+      dir.create(dirname(outfile), recursive = TRUE)
+    }
     saveRDS(results, file = outfile)
     cat("Results saved to:", outfile, "\n")
   }

--- a/docs/developers/comparisons/manual-bullet-comparison-pipeline.R
+++ b/docs/developers/comparisons/manual-bullet-comparison-pipeline.R
@@ -608,7 +608,6 @@ compare_bullets <- function(bullet1_dir, bullet2_dir, outfile = NULL,
 
   cat("\n", paste(rep("=", 60), collapse = ""), "\n")
 
-
   # Prepare minimal results to reduce file size
   # Extract only essential land info (no x3p, ccdata, sigs, etc.)
   lands <- data.frame(

--- a/docs/developers/signals/cts-23-signals.R
+++ b/docs/developers/signals/cts-23-signals.R
@@ -1,0 +1,33 @@
+source("docs/developers/bullet-codes.R")
+source("docs/developers/view-pipeline.R")
+source("docs/developers/comparisons/align-signals.R")
+source("docs/developers/comparisons/comparison-utils.R")
+source("inst/scripts/manual_groove_selection.R")
+
+
+study_dir <- get_study_path("CTS Forensic Testing Program")
+
+# Get bullets cts.23.1.A-C, cts.23.2.A, cts.23.3.A, and cts.23.5.A
+years <- list.dirs(study_dir, recursive = FALSE)
+year <- years[5]
+items <- list.dirs(year, recursive = FALSE)
+bullets <- unlist(lapply(items, function(i) list.dirs(i, recursive = FALSE)))
+bullets <- bullets[-6]
+
+# # Find grooves ----
+# for (bullet in bullets) {
+#   process_directory(bullet, file.path(bullet, "grooves.csv"))
+# }
+
+# Plot signals ----
+lands <- unlist(lapply(bullets, function(b) list.files(b, pattern = "\\.x3p", full.names = TRUE)))
+for (land in lands) {
+  view_pipeline(
+    filepath = land, 
+    grooves_csv = file.path(dirname(land), "grooves.csv"),
+    view_land = FALSE, 
+    view_signal = TRUE, 
+    save_signal_plot = TRUE
+  )
+}
+

--- a/docs/developers/view-pipeline.R
+++ b/docs/developers/view-pipeline.R
@@ -44,15 +44,15 @@ get_optimal_crosscut <- function(x3p) {
 #' selection.
 #'
 #' @param filepath Path to an x3p file
+#' @param grooves_csv Optional path to a CSV file with columns \code{filename},
+#'   \code{crosscut_y}, \code{left_groove}, and \code{right_groove}. When
+#'   provided, the matching row (by \code{basename(filepath)}) supplies the
+#'   crosscut and groove values instead of auto-computing them.
 #' @param view_land Logical; display the x3p land image (default TRUE)
 #' @param view_cc_profile Logical; display the crosscut profile plot (default TRUE)
 #' @param view_grooves Logical; display groove locations and prompt for manual
 #'   selection (default TRUE)
 #' @param view_signal Logical; display the extracted signal plot (default TRUE)
-#' @param grooves_csv Optional path to a CSV file with columns \code{filename},
-#'   \code{crosscut_y}, \code{left_groove}, and \code{right_groove}. When
-#'   provided, the matching row (by \code{basename(filepath)}) supplies the
-#'   crosscut and groove values instead of auto-computing them.
 #' @param save_land_plot Logical; if TRUE, saves the land image to a PNG file
 #'   in the same directory as the input file (default FALSE).
 #' @param save_cc_profile_plot Logical; if TRUE, saves the crosscut profile plot to a PNG file
@@ -82,7 +82,7 @@ get_optimal_crosscut <- function(x3p) {
 #'   view_signal = TRUE
 #' )
 #'
-view_pipeline <- function(filepath, view_land = TRUE, view_cc_profile = FALSE, view_grooves = FALSE, view_signal = FALSE, grooves_csv = NULL, save_land_plot = FALSE, save_cc_profile_plot = FALSE, save_grooves_plot = FALSE, save_signal_plot = FALSE) {
+view_pipeline <- function(filepath, grooves_csv = NULL, view_land = TRUE, view_cc_profile = FALSE, view_grooves = FALSE, view_signal = FALSE, save_land_plot = FALSE, save_cc_profile_plot = FALSE, save_grooves_plot = FALSE, save_signal_plot = FALSE) {
   # Determine the last pipeline step needed based on view/save flags
   # Step mapping: 1=read/land, 2=preprocess, 3=crosscut, 4=grooves, 5=signal
   last_step <- max(c(

--- a/inst/scripts/manual_groove_selection.R
+++ b/inst/scripts/manual_groove_selection.R
@@ -1,12 +1,12 @@
 #!/usr/bin/env Rscript
 # Manual Groove Selection Tool
-# 
+#
 # This script allows manual selection of groove locations from x3p bullet scan files
 # and saves the results to a CSV file for later analysis.
 #
 # Usage:
 #   Rscript manual_groove_selection.R <path_to_x3p_file> [output_csv]
-#   
+#
 # Or interactively in R:
 #   source("manual_groove_selection.R")
 #   process_file("path/to/file.x3p", "groove_data.csv")
@@ -16,18 +16,17 @@ library(bulletxtrctr)
 library(ggplot2)
 
 #' Process a single x3p file for manual groove selection
-#' 
+#'
 #' @param x3p_path Path to the x3p file
 #' @param output_csv Path to output CSV file (default: "groove_locations.csv")
 #' @param crosscut_y Optional crosscut location. If NULL, automatically determined
 #' @return Data frame with the groove locations
 process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut_y = NULL) {
-  
   cat("\n=== Processing:", basename(x3p_path), "===\n")
-  
+
   # Read the x3p file
   x3p <- x3p_read(x3p_path)
-  
+
   # Check orientation and ensure LONG axis is in X direction (matches bulletAnalyzrApp)
   hinfo <- x3p$header.info
   if (hinfo$sizeX < hinfo$sizeY) {
@@ -76,7 +75,7 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
 
     cat("Using optimized crosscut at y =", crosscut_y, "microns\n")
   }
-  
+
   # Extract crosscut data as a 1D profile (range matches bulletAnalyzrApp)
   ccdata <- x3p_crosscut(x3p, y = crosscut_y, range = 1e-5)
 
@@ -84,14 +83,14 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
     cat("Warning: Empty crosscut data, trying with y = NULL\n")
     ccdata <- x3p_crosscut(x3p, y = NULL, range = 1e-5)
   }
-  
+
   # Ensure x coordinates start from 0 and span the full width
   ccdata$x <- ccdata$x - min(ccdata$x, na.rm = TRUE)
-  
+
   # Get automatic groove locations as starting point
   grooves_auto <- cc_locate_grooves(ccdata, method = "middle", adjust = 30, return_plot = FALSE)
   cat("Automatic groove locations:", grooves_auto$groove[1], ",", grooves_auto$groove[2], "\n")
-  
+
   # Plot the crosscut profile
   p <- ggplot(ccdata, aes(x = x, y = value)) +
     geom_line() +
@@ -106,10 +105,10 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
     scale_x_continuous(breaks = scales::pretty_breaks(n = 20)) +
     scale_y_continuous(breaks = scales::pretty_breaks(n = 10)) +
     theme_bw() +
-    theme(text = element_text(size = 14), axis.text.x=element_text(angle = 30, hjust = 1))
-  
+    theme(text = element_text(size = 14), axis.text.x = element_text(angle = 30, hjust = 1))
+
   print(p)
-  
+
   # Interactive input for groove locations
   cat("\n--- Manual Groove Selection ---\n")
   cat("Automatic left groove:", grooves_auto$groove[1], "\n")
@@ -118,14 +117,20 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
   cat("  1. Press ENTER to accept automatic grooves\n")
   cat("  2. Enter custom values as: left,right (e.g., 500,2500)\n")
   cat("  3. Enter 's' to skip this file\n")
-  
+  cat("  4. Enter 'q' to quit and exit the script\n")
+
   user_input <- readline(prompt = "Your choice: ")
-  
+
+  if (tolower(user_input) == "q") {
+    cat("Exiting script.\n")
+    return("QUIT")
+  }
+
   if (tolower(user_input) == "s") {
     cat("Skipping file.\n")
     return(NULL)
   }
-  
+
   if (user_input == "") {
     # Use automatic values
     left_groove <- grooves_auto$groove[1]
@@ -167,8 +172,14 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
         cat("\nOptions:\n")
         cat("  1. Press ENTER to confirm these groove locations\n")
         cat("  2. Enter new values as: left,right (e.g., 500,2500)\n")
+        cat("  3. Enter 'q' to quit and exit the script\n")
 
         confirm_input <- readline(prompt = "Your choice: ")
+
+        if (tolower(confirm_input) == "q") {
+          cat("Exiting script.\n")
+          return("QUIT")
+        }
 
         if (confirm_input == "") {
           # User confirmed the locations
@@ -181,7 +192,7 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
       }
     }
   }
-  
+
   # Prepare data for output
   result <- data.frame(
     filename = basename(x3p_path),
@@ -193,7 +204,7 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
     timestamp = Sys.time(),
     stringsAsFactors = FALSE
   )
-  
+
   # Append to CSV file (or update if file was already processed)
   if (file.exists(output_csv)) {
     existing_data <- read.csv(output_csv, stringsAsFactors = FALSE)
@@ -205,43 +216,49 @@ process_file <- function(x3p_path, output_csv = "groove_locations.csv", crosscut
     # First file - create new CSV
     combined_data <- result
   }
-  
+
   write.csv(combined_data, output_csv, row.names = FALSE)
   cat("\nSaved to", output_csv, "\n")
   cat("Left groove:", left_groove, "\n")
   cat("Right groove:", right_groove, "\n")
-  
+
   return(result)
 }
 
 #' Process multiple x3p files in a directory
-#' 
+#'
 #' @param directory Path to directory containing x3p files
 #' @param output_csv Path to output CSV file
 #' @param pattern File pattern to match (default: "\\.x3p$")
 #' @return Data frame with all groove locations
 process_directory <- function(directory, output_csv = "groove_locations.csv", pattern = "\\.x3p$") {
-  
   x3p_files <- list.files(directory, pattern = pattern, full.names = TRUE, recursive = FALSE)
-  
+
   if (length(x3p_files) == 0) {
     cat("No x3p files found in", directory, "\n")
     return(NULL)
   }
-  
+
   cat("\nFound", length(x3p_files), "x3p files\n")
   cat("Output will be saved to:", output_csv, "\n\n")
-  
+
   results <- list()
-  
+
   for (i in seq_along(x3p_files)) {
     cat("\n[", i, "/", length(x3p_files), "]\n")
     result <- process_file(x3p_files[i], output_csv)
+
+    # Check if user wants to quit
+    if (identical(result, "QUIT")) {
+      cat("\nExiting. Processed", i - 1, "of", length(x3p_files), "files.\n")
+      stop("QUIT")
+    }
+
     if (!is.null(result)) {
       results[[i]] <- result
     }
   }
-  
+
   # Combine all results
   if (length(results) > 0) {
     all_results <- do.call(rbind, results)
@@ -254,7 +271,7 @@ process_directory <- function(directory, output_csv = "groove_locations.csv", pa
 # Command line interface
 if (!interactive()) {
   args <- commandArgs(trailingOnly = TRUE)
-  
+
   if (length(args) == 0) {
     cat("Usage: Rscript manual_groove_selection.R <x3p_file_or_directory> [output_csv]\n")
     cat("\nExamples:\n")
@@ -263,10 +280,10 @@ if (!interactive()) {
     cat("  Rscript manual_groove_selection.R examples/Hamby-44/Barrel_1/Bullet_1/ grooves.csv\n")
     quit(status = 1)
   }
-  
+
   input_path <- args[1]
   output_csv <- if (length(args) >= 2) args[2] else "groove_locations.csv"
-  
+
   if (dir.exists(input_path)) {
     # Process directory
     process_directory(input_path, output_csv)


### PR DESCRIPTION
## Summary
- Extract `get_study_path()` into `comparison-utils.R` to replace duplicated directory detection logic across comparison scripts
- Add `compare-hamby44.R` script for running the manual comparison pipeline on Hamby Set 44
- Add quit option ('q') to the manual groove selection tool for easier workflow interruption
- Update developer documentation to reflect new/renamed scripts and improved descriptions

## Test plan
- [x] Source `comparison-utils.R` and verify `get_study_path()` resolves paths correctly
- [x] Run `compare-phoenix.R` and confirm it uses the centralized path helper
- [x] Run `compare-hamby44.R` end-to-end on Hamby Set 44 scans
- [x] Test manual groove selection quit option ('q') exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)